### PR TITLE
Add eslintrc.yml to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,8 @@
 .editorconfig
 .ember-cli
 .gitignore
-.jshintrc
+.eslintignore
+.eslintrc.yml
 .watchmanconfig
 .travis.yml
 bower.json


### PR DESCRIPTION
Update `.npmignore` so the NPM package doesn't include eslint files.