### PR TITLE
fix ember-cli-node-assets usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,15 +11,22 @@ module.exports = {
     return path.join(__dirname, "blueprints");
   },
 
-  nodeAssets: {
-    flickity: {
-      vendor: {
-        include: ["dist/flickity.pkgd.js"],
-        processTree(input) {
-          return fastbootTransform(input);
+  options: {
+    nodeAssets: {
+      flickity: {
+        vendor: {
+          include: ["dist/flickity.pkgd.js"],
+          processTree(input) {
+            return fastbootTransform(input);
+          }
         }
       }
     }
+  },
+
+  included() {
+    this._super.included.apply(this, arguments);
+    this.import("vendor/flickity/dist/flickity.pkgd.js");
   },
 
   isDevelopingAddon() {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-cli-eslint": "1.7.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-import-polyfill": "^0.2.0",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-mocha": "0.13.1",
     "ember-cli-release": "^0.2.9",


### PR DESCRIPTION
@dylanfoster I misunderstood how ember-cli-node-assets worked, causing a breaking change for apps which consume this addon. 

The tests pass because of how ember-cli-build.js works with an addon's tests.